### PR TITLE
Compability for .NET Core 3.0 (preview 6)

### DIFF
--- a/Discord.OAuth2.targets
+++ b/Discord.OAuth2.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionSuffix>-preview</VersionSuffix>
     <Authors>RogueException</Authors>
     <PackageTags>discord;discordapp;aspnetcore;authentication;security</PackageTags>
     <PackageProjectUrl>https://github.com/RogueException/Discord.OAuth2</PackageProjectUrl>

--- a/src/Discord.OAuth2/Discord.OAuth2.csproj
+++ b/src/Discord.OAuth2/Discord.OAuth2.csproj
@@ -4,9 +4,9 @@
     <Description>ASP.Net Core middleware that enables an application to support Discord's OAuth 2.0 authentication workflow.</Description>
     <RootNamespace>Discord.OAuth2</RootNamespace>
     <AssemblyName>Discord.OAuth2</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="2.1.1" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/src/Discord.OAuth2/DiscordHandler.cs
+++ b/src/Discord.OAuth2/DiscordHandler.cs
@@ -28,13 +28,9 @@ namespace Discord.OAuth2
             if (!response.IsSuccessStatusCode)
                 throw new HttpRequestException($"Failed to retrieve Discord user information ({response.StatusCode}).");
 
-            JsonElement rootElement;
-            using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
-            {
-                rootElement = payload.RootElement;
-            }
+            using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
 
-            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, rootElement);
+            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
             await Events.CreatingTicket(context);

--- a/src/Discord.OAuth2/DiscordHandler.cs
+++ b/src/Discord.OAuth2/DiscordHandler.cs
@@ -2,11 +2,11 @@
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Discord.OAuth2
@@ -28,9 +28,9 @@ namespace Discord.OAuth2
             if (!response.IsSuccessStatusCode)
                 throw new HttpRequestException($"Failed to retrieve Discord user information ({response.StatusCode}).");
 
-            var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
+            var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
 
-            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload);
+            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
             await Events.CreatingTicket(context);

--- a/src/Discord.OAuth2/DiscordHandler.cs
+++ b/src/Discord.OAuth2/DiscordHandler.cs
@@ -28,9 +28,13 @@ namespace Discord.OAuth2
             if (!response.IsSuccessStatusCode)
                 throw new HttpRequestException($"Failed to retrieve Discord user information ({response.StatusCode}).");
 
-            var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            JsonElement rootElement;
+            using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
+            {
+                rootElement = payload.RootElement;
+            }
 
-            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
+            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, rootElement);
             context.RunClaimActions();
 
             await Events.CreatingTicket(context);


### PR DESCRIPTION
In accordance with https://github.com/aspnet/AspNetCore/issues/3756 and https://github.com/aspnet/AspNetCore/issues/3612 this pull requests creates compability for .NET Core 3.0.

This PR contains the breaking change that the library has to target .NET Core 3.0.

Primary changes in `Discord.OAuth2.csproj` and `DiscordHandler.cs`.
Changes in `Discord.OAuth2.targets` are optional, eventually to be replaced later.